### PR TITLE
Fixed overlay warnings for location buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-<<<<<<< HEAD
-
 # Goober
 
 Web App for Autonomous Intersection Regulation (AIR) Project by Caio DaSilva, Scott Abramson, Aidan Hanson, and Vladyslav Aviedov

--- a/app/components/LocationButton.tsx
+++ b/app/components/LocationButton.tsx
@@ -16,8 +16,15 @@ const LocationButton = ({ location, onLocSelect }) => {
     <OverlayTrigger
       key={location.id}
       placement="bottom"
-      overlay={
-        <Box>
+      overlay={({
+        placement: _placement,
+        arrowProps: _arrowProps,
+        show: _show,
+        popper: _popper,
+        hasDoneInitialMeasure: _hasDoneInitialMeasure,
+        ...props
+      }) => (
+        <Box {...props}>
           {location.occupied ? (
             <Box
               sx={{
@@ -58,7 +65,7 @@ const LocationButton = ({ location, onLocSelect }) => {
             </Box>
           )}
         </Box>
-      }
+      )}
     >
       <Box
         position="absolute"


### PR DESCRIPTION
I changed the Overlay declaration to how React Bootstrap wiki does it.
https://react-bootstrap.netlify.app/docs/components/overlays/#overlay

React sure is strange, huh.